### PR TITLE
Fix duplicate check_config in Google LLM

### DIFF
--- a/dazllm/llm_google.py
+++ b/dazllm/llm_google.py
@@ -48,14 +48,6 @@ class LlmGoogle(Llm):
                     "  pip install google-generativeai  (older API)"
                 )
 
-    @staticmethod
-    def check_config():
-        """Check if Google is properly configured"""
-        api_key = keyring.get_password("dazllm", "google_api_key")
-        if not api_key:
-            raise ConfigurationError(
-                "Google API key not found in keyring. Set with: keyring set dazllm google_api_key"
-            )
 
     @staticmethod
     def default_model() -> str:


### PR DESCRIPTION
## Summary
- remove the duplicate `check_config` definition from `llm_google.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'keyring', No module named 'colorama')*

------
https://chatgpt.com/codex/tasks/task_e_685f353bfa108327b26be2fc463a5818