### PR TITLE
Fix PyPI banner

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include README.md
 include LICENSE
 include requirements.txt
+include banner.jpg
 include MANIFEST.in
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]


### PR DESCRIPTION
## Summary
- include the banner image in MANIFEST.in so the README banner renders on PyPI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for keyring and colorama)*

------
https://chatgpt.com/codex/tasks/task_e_685f353a38cc8327a5e9211be54e8579