### PR TITLE
Add google-ai-generativelanguage dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "openai>=1.0.0", 
     "anthropic>=0.3.0",
     "google-generativeai>=0.3.0",
+    "google-ai-generativelanguage",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- update `pyproject.toml` dependencies to include `google-ai-generativelanguage`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'keyring')*

------
https://chatgpt.com/codex/tasks/task_e_685f353685a48327b3c7ac02a35560e5