### PR TITLE
Remove duplicate version constant

### DIFF
--- a/dazllm/core.py
+++ b/dazllm/core.py
@@ -8,8 +8,6 @@ from typing import Optional, Union, Dict, List, Type, Literal, TypedDict, Set
 from pydantic import BaseModel
 from enum import Enum
 
-__version__ = "0.1.0"
-
 
 class Message(TypedDict):
     role: Literal["user", "assistant", "system"]


### PR DESCRIPTION
## Summary
- clean up `core` by removing the `__version__` constant

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'keyring')*

------
https://chatgpt.com/codex/tasks/task_e_685f3531225c832784611ea1d7fc667c